### PR TITLE
Added FLEX type

### DIFF
--- a/src/main/java/infobip/api/model/omni/send/LineDataType.java
+++ b/src/main/java/infobip/api/model/omni/send/LineDataType.java
@@ -8,5 +8,6 @@ public enum LineDataType {
     IMAGE,
     VIDEO,
     AUDIO,
-    STICKER
+    STICKER,
+    FLEX
 }


### PR DESCRIPTION
Hi, when we use this client to handle omni request , we have no option to use FLEX type.
But the Infobip can work on this type actually. So I create this pull request to solve client doesn't support FLEX type.